### PR TITLE
Add Expires and Cache-Control: max-age response headers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ build
 dist
 htmlcov
 venv
+.venv
 .coverage
 .tox
 .idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 2024.10.5
 - Reorganize routers internally.
 - Setup GitHub actions.
 - Migrate to uv.
+- Add Expires and Cache-Control: max-age response headers.
 - First OSS release.
 
 

--- a/README.md
+++ b/README.md
@@ -42,21 +42,18 @@ The API documentation is available at:
 
 ## Remote deployment
 
-To make a release, build and publish the Docker images to the GitLab
-registry, you need to:
+To make a release, build and publish the Docker image to the Docker Hub  registry, you need to:
 
--   push a tag to the main branch using git, or
--   create a tag through the GitLab UI.
+-   create a release through the GitHub UI (preferred), or
+-   push a tag to the main branch using git.
 
-The format of the tag should be `YYYY.MM.DD`, where:
+The format of the tag should be `YYYY.M.N`, where:
 
--   `YYYY` is the full year (2006, 2016, 2106 ...)
--   `MM` is the short month, not zero-padded (1, 2 ... 11, 12)
--   `DD` is any incremental number, not zero-padded (it doesn't need to be the day)
+-   `YYYY` is the full year (2024, 2025...)
+-   `M` is the short month, not zero-padded (1, 2 ... 11, 12)
+-   `N` is any incremental number, not zero-padded (it doesn't need to be the day)
 
-The new Docker images are automatically deployed after a few minutes.
-
-See also the configuration files at <https://bbpgitlab.epfl.ch/project/sbo/k8s>.
+The new Docker image is automatically pushed to Docker Hub as part of the CI pipeline.
 
 
 ## Local build and deployment

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -54,6 +54,12 @@ http {
     # $3 = millisecond part of $msec e.g. 123 extracted from 1621594635.123
     map "$time_iso8601 # $msec" $time_iso8601_ms { "~(^[^+]+)(\+[0-9:]+) # \d+\.(\d+)$" $1.$3$2; }
 
+    # set Expires and Cache-Control: max-age headers, if Cache-Control is not set by the upstream
+    map $upstream_http_cache_control $expires {
+        '' 3600;
+        default off;
+    }
+    expires $expires;
 
     server {
         listen 8000;

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -38,6 +38,7 @@ async def client_error_handler(request: Request, exc: ClientError) -> JSONRespon
 
 app = FastAPI(
     title=settings.APP_NAME,
+    version=settings.APP_VERSION or "0.0.0",
     debug=settings.APP_DEBUG,
     lifespan=lifespan,
     root_path=settings.ROOT_PATH,


### PR DESCRIPTION
By explicitly adding `Cache-Control: max-age`, the browser should use the local cache.
Only after the expiration, it will check with the server if the etag changed.
Without the header, instead, the browser is probably using a heuristic logic, that doesn't work as expected anymore after the header `Cache-Control: private` has been added.